### PR TITLE
Ability to set head block time drift and number metric name on run

### DIFF
--- a/app/nodeos_mindreader/app.go
+++ b/app/nodeos_mindreader/app.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/dfuse-io/dgrpc"
+	"github.com/dfuse-io/manageos/metrics"
 	"github.com/dfuse-io/manageos/mindreader"
 	nodeosMindreader "github.com/dfuse-io/manageos/mindreader/nodeos"
 	"github.com/dfuse-io/manageos/operator"
@@ -33,6 +34,7 @@ import (
 )
 
 type Config struct {
+	MetricID            string
 	ManagerAPIAddress   string
 	NodeosAPIAddress    string
 	ConnectionWatchdog  bool
@@ -97,7 +99,15 @@ func (a *App) Run() error {
 	hostname, _ := os.Hostname()
 	zlog.Info("retrieved hostname from os", zap.String("hostname", hostname))
 
-	chainSuperviser, err := nodeos.NewSuperviser(zlog, zlogNodeos, a.Config.DebugDeepMind, &nodeos.SuperviserOptions{
+	metricID := a.Config.MetricID
+	if metricID == "" {
+		metricID = "manager"
+	}
+	zlog.Info("setting up metrics", zap.String("metric_id", metricID))
+	headBlockTimeDrift := metrics.NewHeadBlockTimeDrift(metricID)
+	headBlockNumber := metrics.NewHeadBlockNumber(metricID)
+
+	chainSuperviser, err := nodeos.NewSuperviser(zlog, zlogNodeos, a.Config.DebugDeepMind, headBlockTimeDrift, headBlockNumber, &nodeos.SuperviserOptions{
 		LocalNodeEndpoint:   a.Config.NodeosAPIAddress,
 		ConfigDir:           a.Config.NodeosConfigDir,
 		BinPath:             a.Config.NodeosBinPath,
@@ -152,6 +162,8 @@ func (a *App) Run() error {
 		a.Config.StartBlockNum,
 		a.Config.StopBlockNum,
 		a.Config.MindReadBlocksChanCapacity,
+		headBlockTimeDrift,
+		headBlockNumber,
 		chainOperator.SetMaintenance,
 	)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cloud.google.com/go/storage v1.4.0
 	github.com/ShinyTrinkets/overseer v0.3.0
 	github.com/abourget/llerrgroup v0.0.0-20161118145731-75f536392d17
-	github.com/dfuse-io/bstream v0.0.0-20200415154805-fc5f1d364031
+	github.com/dfuse-io/bstream v0.0.0-20200415195700-4274669bdcb6
 	github.com/dfuse-io/dbin v0.0.0-20200406215642-ec7f22e794eb
 	github.com/dfuse-io/dgrpc v0.0.0-20200406214416-6271093e544c
 	github.com/dfuse-io/dmetrics v0.0.0-20200406214800-499fc7b320ab

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dfuse-io/bstream v0.0.0-20200415154805-fc5f1d364031 h1:IWo0BA3byIQELkm6itE0BN04yjopwl+KCedirhDCpII=
-github.com/dfuse-io/bstream v0.0.0-20200415154805-fc5f1d364031/go.mod h1:tCeWgLk5bsjFO/pj8c6b0iX2rJAEt1Z86twwg7CHlHQ=
+github.com/dfuse-io/bstream v0.0.0-20200415195700-4274669bdcb6 h1:EiFraZG2BlTbsepuCkE4gsEOfrDH/7ThFhsliDqbLs0=
+github.com/dfuse-io/bstream v0.0.0-20200415195700-4274669bdcb6/go.mod h1:tCeWgLk5bsjFO/pj8c6b0iX2rJAEt1Z86twwg7CHlHQ=
 github.com/dfuse-io/dbin v0.0.0-20200406215642-ec7f22e794eb h1:yrE/Ncb9PAjdN7w5Ixx47Oy1kQQdluBfuv7c8D9UaPQ=
 github.com/dfuse-io/dbin v0.0.0-20200406215642-ec7f22e794eb/go.mod h1:yMMhO8IdiSS+R/961s9Ac1oyAx3MdAO0OneSZ9Wt/Wg=
 github.com/dfuse-io/derr v0.0.0-20200406214256-c690655246a1 h1:ejixSugMZ417KvnJhk4cZJu/VW4ql0AlL+seE4jh1Kc=

--- a/metrics/common.go
+++ b/metrics/common.go
@@ -22,12 +22,21 @@ import (
 
 var metricset = dmetrics.NewSet()
 
-var HeadBlockTimeDrift = metricset.NewHeadTimeDrift("manager")
-var HeadBlockNumber = metricset.NewHeadBlockNumber("manager")
+//var HeadBlockTimeDrift = metricset.NewHeadTimeDrift("manager")
+//var HeadBlockNumber = metricset.NewHeadBlockNumber("manager")
 var SuccessfulBackups = metricset.NewCounter("successful_backups", "This counter increments every time that a backup is completed successfully")
 
-func init() {
+func NewHeadBlockTimeDrift(serviceName string) *dmetrics.HeadTimeDrift {
+	return metricset.NewHeadTimeDrift(serviceName)
+}
+
+func NewHeadBlockNumber(serviceName string) *dmetrics.HeadBlockNum {
+	return metricset.NewHeadBlockNumber(serviceName)
+}
+
+func RegisterMetrics() {
 	if _, err := os.Stat("/.dockerenv"); !os.IsNotExist(err) {
+		// occurs whilte in docker env
 		metricset.Register()
 	}
 }

--- a/metrics/common.go
+++ b/metrics/common.go
@@ -22,8 +22,6 @@ import (
 
 var metricset = dmetrics.NewSet()
 
-//var HeadBlockTimeDrift = metricset.NewHeadTimeDrift("manager")
-//var HeadBlockNumber = metricset.NewHeadBlockNumber("manager")
 var SuccessfulBackups = metricset.NewCounter("successful_backups", "This counter increments every time that a backup is completed successfully")
 
 func NewHeadBlockTimeDrift(serviceName string) *dmetrics.HeadTimeDrift {
@@ -34,7 +32,7 @@ func NewHeadBlockNumber(serviceName string) *dmetrics.HeadBlockNum {
 	return metricset.NewHeadBlockNumber(serviceName)
 }
 
-func RegisterMetrics() {
+func init() {
 	if _, err := os.Stat("/.dockerenv"); !os.IsNotExist(err) {
 		// occurs whilte in docker env
 		metricset.Register()

--- a/mindreader/archiver_test.go
+++ b/mindreader/archiver_test.go
@@ -25,10 +25,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dfuse-io/dgrpc"
-
 	"github.com/dfuse-io/bstream"
 	"github.com/dfuse-io/bstream/blockstream"
+	"github.com/dfuse-io/dgrpc"
 	"github.com/dfuse-io/dstore"
 	"github.com/eoscanada/eos-go"
 	"github.com/klauspost/compress/zstd"
@@ -194,6 +193,8 @@ func testNewMindReaderPlugin(archiver Archiver, gator Gator, startBlockNum uint6
 		gator,
 		startBlockNum,
 		10,
+		nil,
+		nil,
 	)
 }
 

--- a/mindreader/mindreader.go
+++ b/mindreader/mindreader.go
@@ -161,6 +161,8 @@ func NewMindReaderPlugin(
 		gator:               gator,
 		stopAtBlockNum:      stopAtBlockNum,
 		channelCapacity:     channelCapacity,
+		headBlockTimeDrift:  headBlockTimeDrift,
+		headBlockNumber:     headBlockNumber,
 	}, nil
 }
 
@@ -273,6 +275,7 @@ func (p *MindReaderPlugin) readOneMessage(blocks chan<- *bstream.Block) error {
 	}
 	if p.headBlockTimeDrift != nil {
 		p.headBlockTimeDrift.SetBlockTime(block.Time())
+
 	}
 
 	blocks <- block

--- a/superviser/nodeos/monitoring.go
+++ b/superviser/nodeos/monitoring.go
@@ -59,8 +59,8 @@ func (s *NodeosSuperviser) Monitor() {
 
 		lastHeadBlockTime = chainInfo.HeadBlockTime.Time
 		if s.options.MonitorHeadBlock {
-			metrics.HeadBlockNumber.SetUint64(uint64(chainInfo.HeadBlockNum))
-			metrics.HeadBlockTimeDrift.SetBlockTime(lastHeadBlockTime)
+			s.headBlockNumber.SetUint64(uint64(chainInfo.HeadBlockNum))
+			s.headBlockTimeDrift.SetBlockTime(lastHeadBlockTime)
 		}
 
 		if s.options.ReadinessMaxLatency == 0 || time.Since(lastHeadBlockTime) < s.options.ReadinessMaxLatency {


### PR DESCRIPTION
Currently the mindreader and the producer, both register a head block number & drift with the name "manager". This has as effect that `dfuse-eosio` cannot distinguish between both application for the metric value `head_block_number` & `head_block_time_drift`. We need to configure the name of the Head block number and drift metric on runtime. 

while running `dfuse-eosio` locally, open your browser @ `localhost:9102`. Currently you should see
```
...
head_block_number{app="manager"} 170
...
```

the goal would be to see

```
...
head_block_number{app="producer"} 170
head_block_number{app="mindreader"} 172
...
```


Re Issue: https://github.com/dfuse-io/dfuse-eosio/issues/15