### PR TITLE
prevent hole restarting after stopblock premerged

### DIFF
--- a/app/nodeos_mindreader/app.go
+++ b/app/nodeos_mindreader/app.go
@@ -223,7 +223,13 @@ func (a *App) Run() error {
 		go chainSuperviser.LaunchConnectionWatchdog(chainOperator.Terminating())
 	}
 
-	startNodeosOnLaunch := !mindreaderLogPlugin.ContinuityChecker.IsLocked()
+	var startNodeosOnLaunch bool
+	if mindreaderLogPlugin.ContinuityChecker.IsLocked() {
+		zlog.Error("continuity checker shows that a hole was previously detected. NOT STARTING PROCESS WITHOUT MANUAL reset_cc or restore")
+	} else {
+		startNodeosOnLaunch = true
+	}
+
 	httpOptions := []operator.HTTPOption{
 		func(r *mux.Router) {
 			r.HandleFunc("/v1/reset_cc", func(w http.ResponseWriter, r *http.Request) {

--- a/app/nodeos_mindreader/app.go
+++ b/app/nodeos_mindreader/app.go
@@ -74,10 +74,12 @@ type Config struct {
 	ShutdownDelay       time.Duration
 
 	ArchiveStoreURL            string
+	MergeArchiveStoreURL       string
 	MergeUploadDirectly        bool
 	GRPCAddr                   string
 	StartBlockNum              uint64
 	StopBlockNum               uint64
+	DiscardAfterStopBlock      bool
 	MindReadBlocksChanCapacity int
 	WorkingDir                 string
 
@@ -179,7 +181,9 @@ func (a *App) Run() error {
 	zlog.Info("launching mindreader plugin")
 	mindreaderLogPlugin, err := mindreader.RunMindReaderPlugin(
 		a.Config.ArchiveStoreURL,
+		a.Config.MergeArchiveStoreURL,
 		a.Config.MergeUploadDirectly,
+		a.Config.DiscardAfterStopBlock,
 		a.Config.WorkingDir,
 		nodeosMindreader.BlockFileNamer,
 		a.modules.ConsoleReaderFactory,

--- a/mindreader/archiver.go
+++ b/mindreader/archiver.go
@@ -41,13 +41,6 @@ type Archiver interface {
 	uploadFiles() error
 	cleanup()
 }
-type OneblockArchiverOption func(*OneblockArchiver)
-
-func WithDiscardFromStopBlock(stopBlock uint64) OneblockArchiverOption {
-	return func(a *OneblockArchiver) {
-		a.stopBlock = stopBlock
-	}
-}
 
 type OneblockArchiver struct {
 	store              dstore.Store
@@ -64,19 +57,14 @@ func NewOneblockArchiver(
 	blockFileNamer BlockFileNamer,
 	blockWriterFactory bstream.BlockWriterFactory,
 	stopBlock uint64,
-	options ...OneblockArchiverOption,
 ) *OneblockArchiver {
-	da := &OneblockArchiver{
+	return &OneblockArchiver{
 		store:              store,
 		blockFileNamer:     blockFileNamer,
 		blockWriterFactory: blockWriterFactory,
 		workDir:            workDir,
 		stopBlock:          stopBlock,
 	}
-	for _, opt := range options {
-		opt(da)
-	}
-	return da
 }
 
 // cleanup assumes that no more 'storeBlock' command is coming

--- a/mindreader/archiver_test.go
+++ b/mindreader/archiver_test.go
@@ -180,8 +180,8 @@ func TestNewGSStore(t *testing.T) {
 	require.True(t, exists)
 }
 
-func testNewArchiver(path string, store dstore.Store) *DefaultArchiver {
-	return NewDefaultArchiver(path, store, testBlockFileNamer, testBlockWriteFactory)
+func testNewArchiver(path string, store dstore.Store) *OneblockArchiver {
+	return NewOneblockArchiver(path, store, testBlockFileNamer, testBlockWriteFactory, 0)
 }
 
 func testNewMindReaderPlugin(archiver Archiver, gator Gator, startBlockNum uint64) (*MindReaderPlugin, error) {

--- a/mindreader/init_test.go
+++ b/mindreader/init_test.go
@@ -45,6 +45,9 @@ func (s *TestStore) init() error {
 	return nil
 }
 
+func (s *TestStore) cleanup() {
+}
+
 func (s *TestStore) storeBlock(block *bstream.Block) error {
 	s.blocks = append(s.blocks, block)
 	s.receivedBlock <- block

--- a/mindreader/merge_archiver.go
+++ b/mindreader/merge_archiver.go
@@ -67,7 +67,7 @@ func WithOverflowArchiver(archiver Archiver) MergeArchiverOption {
 
 func (m *MergeArchiver) init() error {
 	if m.overflowArchiver != nil {
-		m.overflowArchiver.init()
+		return m.overflowArchiver.init()
 	}
 	return nil
 }

--- a/mindreader/merge_archiver.go
+++ b/mindreader/merge_archiver.go
@@ -26,12 +26,12 @@ import (
 	"go.uber.org/zap"
 )
 
-// ReprocArchiver does the merging in one swift, no need for a merger here.
-type ReprocArchiver struct {
-	store                    dstore.Store
-	blockWriterFactory       bstream.BlockWriterFactory
-	stopBlock                uint64
-	passthroughFromStopBlock Archiver
+// MergeArchiver does the merging in one swift, no need for a merger here.
+type MergeArchiver struct {
+	store              dstore.Store
+	blockWriterFactory bstream.BlockWriterFactory
+	stopBlock          uint64
+	overflowArchiver   Archiver
 
 	eg          *llerrgroup.Group
 	expectBlock uint64
@@ -39,14 +39,16 @@ type ReprocArchiver struct {
 	blockWriter bstream.BlockWriter
 }
 
-func NewReprocArchiver(
+func NewMergeArchiver(
 	store dstore.Store,
 	blockWriterFactory bstream.BlockWriterFactory,
-	options ...ReprocOption,
-) *ReprocArchiver {
-	ra := &ReprocArchiver{
+	stopBlock uint64,
+	options ...MergeArchiverOption,
+) *MergeArchiver {
+	ra := &MergeArchiver{
 		eg:                 llerrgroup.New(2),
 		store:              store,
+		stopBlock:          stopBlock,
 		blockWriterFactory: blockWriterFactory,
 	}
 	for _, opt := range options {
@@ -55,96 +57,91 @@ func NewReprocArchiver(
 	return ra
 }
 
-type ReprocOption func(*ReprocArchiver)
+type MergeArchiverOption func(*MergeArchiver)
 
-func WithReprocDiscardFromStopBlock(stopBlock uint64) ReprocOption {
-	return func(r *ReprocArchiver) {
-		r.stopBlock = stopBlock
+func WithOverflowArchiver(archiver Archiver) MergeArchiverOption {
+	return func(r *MergeArchiver) {
+		r.overflowArchiver = archiver
 	}
 }
 
-func WithReprocPassthroughFromStopBlock(stopBlock uint64, archiver Archiver) ReprocOption {
-	return func(r *ReprocArchiver) {
-		r.passthroughFromStopBlock = archiver
-		r.stopBlock = stopBlock
-		r.passthroughFromStopBlock.init()
+func (m *MergeArchiver) init() error {
+	if m.overflowArchiver != nil {
+		m.overflowArchiver.init()
 	}
-}
-
-func (s *ReprocArchiver) init() error {
 	return nil
 }
 
-func (s *ReprocArchiver) newBuffer() error {
-	s.buffer = &bytes.Buffer{}
-	blockWriter, err := s.blockWriterFactory.New(s.buffer)
+func (m *MergeArchiver) newBuffer() error {
+	m.buffer = &bytes.Buffer{}
+	blockWriter, err := m.blockWriterFactory.New(m.buffer)
 	if err != nil {
 		return fmt.Errorf("blockWriteFactory: %s", err)
 	}
-	s.blockWriter = blockWriter
+	m.blockWriter = blockWriter
 	return nil
 }
 
 // cleanup assumes that no more 'storeBlock' command is coming
-func (s *ReprocArchiver) cleanup() {
-	s.eg.Wait()
-	if s.passthroughFromStopBlock != nil {
-		s.passthroughFromStopBlock.cleanup()
+func (m *MergeArchiver) cleanup() {
+	m.eg.Wait()
+	if m.overflowArchiver != nil {
+		m.overflowArchiver.cleanup()
 	}
 }
 
-func (s *ReprocArchiver) storeBlock(block *bstream.Block) error {
-	if s.buffer == nil && block.Num() < 3 {
+func (m *MergeArchiver) storeBlock(block *bstream.Block) error {
+	if m.buffer == nil && block.Num() < 3 {
 		// Special case the beginning of the EOS chain
 
-		if err := s.newBuffer(); err != nil {
+		if err := m.newBuffer(); err != nil {
 			return err
 		}
-		s.expectBlock = block.Num()
+		m.expectBlock = block.Num()
 	}
 
 	if block.Num()%100 == 0 {
-		if err := s.newBuffer(); err != nil {
+		if err := m.newBuffer(); err != nil {
 			return err
 		}
 
-		if s.expectBlock == 0 {
-			s.expectBlock = block.Num()
+		if m.expectBlock == 0 {
+			m.expectBlock = block.Num()
 		}
 	}
 
-	if s.buffer == nil {
+	if m.buffer == nil {
 		zlog.Info("ignore blocks before beginning of 100-blocks boundary", zap.Uint64("block_num", block.Num()))
 		return nil
 	}
 
-	if s.stopBlock != 0 && block.Num() >= s.stopBlock {
-		if s.passthroughFromStopBlock != nil {
-			return s.passthroughFromStopBlock.storeBlock(block)
+	if m.stopBlock != 0 && block.Num() >= m.stopBlock {
+		if m.overflowArchiver != nil {
+			return m.overflowArchiver.storeBlock(block)
 		}
 		zlog.Debug("ignoring block after stop_block because no passthrough is set", zap.Uint64("block_num", block.Num()))
 		return nil
 	}
 
-	if s.expectBlock != block.Num() {
-		return fmt.Errorf("blocks non contiguous, expectedBlock: %d, got block: %d", s.expectBlock, block.Num())
+	if m.expectBlock != block.Num() {
+		return fmt.Errorf("blocks non contiguous, expectedBlock: %d, got block: %d", m.expectBlock, block.Num())
 	}
-	s.expectBlock++
+	m.expectBlock++
 
-	if err := s.blockWriter.Write(block); err != nil {
+	if err := m.blockWriter.Write(block); err != nil {
 		return fmt.Errorf("blockWriter.Write: %s", err)
 	}
 
 	if block.Num()%100 == 99 {
 
-		if s.eg.Stop() {
+		if m.eg.Stop() {
 			return nil // already errored
 		}
 
 		baseNum := block.Num() - 99
 		baseName := fmt.Sprintf("%010d", baseNum)
-		buffer := s.buffer
-		s.eg.Go(func() error {
+		buffer := m.buffer
+		m.eg.Go(func() error {
 			if baseNum%1000 == 0 {
 				zlog.Info("writing merged blocks log (%1000)", zap.String("base_name", baseName))
 			}
@@ -152,7 +149,7 @@ func (s *ReprocArchiver) storeBlock(block *bstream.Block) error {
 			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 			defer cancel()
 
-			err := s.store.WriteObject(ctx, baseName, bytes.NewReader(buffer.Bytes()))
+			err := m.store.WriteObject(ctx, baseName, bytes.NewReader(buffer.Bytes()))
 			if err != nil {
 				return fmt.Errorf("uploading merged file: %s", err)
 			}
@@ -164,6 +161,6 @@ func (s *ReprocArchiver) storeBlock(block *bstream.Block) error {
 }
 
 // uploadFiles does nothing here, it's managed by `storeBlock` when needed
-func (s *ReprocArchiver) uploadFiles() error {
+func (m *MergeArchiver) uploadFiles() error {
 	return nil
 }

--- a/mindreader/merge_archiver_test.go
+++ b/mindreader/merge_archiver_test.go
@@ -32,9 +32,9 @@ func init() {
 		}, nil
 	})
 }
-func TestReprocArchiver(t *testing.T) {
+func TestMergeArchiver(t *testing.T) {
 	mStore := dstore.NewMockStore(nil)
-	a := &ReprocArchiver{
+	a := &MergeArchiver{
 		store:              mStore,
 		blockWriterFactory: bstream.GetBlockWriterFactory,
 		eg:                 llerrgroup.New(2),
@@ -62,9 +62,9 @@ func TestReprocArchiver(t *testing.T) {
 	assert.Equal(t, uint64(200), a.expectBlock)
 }
 
-func TestReprocArchiverSpecialCase(t *testing.T) {
+func TestMergeArchiverSpecialCase(t *testing.T) {
 	mStore := dstore.NewMockStore(nil)
-	a := &ReprocArchiver{
+	a := &MergeArchiver{
 		store:              mStore,
 		blockWriterFactory: bstream.GetBlockWriterFactory,
 	}

--- a/mindreader/mindreader.go
+++ b/mindreader/mindreader.go
@@ -105,9 +105,6 @@ func RunMindReaderPlugin(
 	if err != nil {
 		return nil, fmt.Errorf("error setting up continuity checker: %s", err)
 	}
-	if cc.IsLocked() {
-		zlog.Error("continuity checker shows that a hole was previously detected. NOT STARTING PROCESS WITHOUT MANUAL reset_cc or restore")
-	}
 
 	var archiver Archiver
 	if mergeUploadDirectly {


### PR DESCRIPTION
When using MergeUploadDirectly, after reaching StopBlockNum, mindreader
will start creating one-block-files, so that the merger can continue
after restart.

This Addresses dfuse-eosio#30, and is discussed in dfuse-eosio#26

* New config params:
  * MergeArchiveStoreURL (instead of reusing ArchiveStoreURL)
  * DiscardAfterStopBlock -> revert to old behavior, blocks above
      StopBlockNum will always be discarded