### PR TITLE
Delete content of state folder instead of the folder itself

### DIFF
--- a/superviser/nodeos/superviser.go
+++ b/superviser/nodeos/superviser.go
@@ -153,8 +153,7 @@ func (s *NodeosSuperviser) GetCommand() string {
 
 func (s *NodeosSuperviser) HasData() bool {
 	dir, err := ioutil.ReadDir(s.blocksDir)
-	// there should be blocks.log, blocks.index and the reversible folder
-	if err != nil || len(dir) < 3 {
+	if err != nil || len(dir) == 0 {
 		return false
 	}
 	dir, err = ioutil.ReadDir(path.Join(s.options.DataDir, "state"))
@@ -173,7 +172,7 @@ func (s *NodeosSuperviser) removeState() error {
 	for _, file := range dir {
 		err = os.RemoveAll(path.Join(stateDir, file.Name()))
 		if err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("cannot delete state: %w", err)
+			return fmt.Errorf("cannot delete state element: %w", err)
 		}
 	}
 	return nil

--- a/superviser/nodeos/superviser.go
+++ b/superviser/nodeos/superviser.go
@@ -152,9 +152,16 @@ func (s *NodeosSuperviser) GetCommand() string {
 }
 
 func (s *NodeosSuperviser) HasData() bool {
-	_, blockErr := os.Stat(s.blocksDir)
-	_, stateErr := os.Stat(path.Join(s.options.DataDir, "state"))
-	return blockErr == nil && stateErr == nil
+	dir, err := ioutil.ReadDir(s.blocksDir)
+	// there should be blocks.log, blocks.index and the reversible folder
+	if err != nil || len(dir) < 3 {
+		return false
+	}
+	dir, err = ioutil.ReadDir(path.Join(s.options.DataDir, "state"))
+	if err != nil || len(dir) == 0 {
+		return false
+	}
+	return true
 }
 
 func (s *NodeosSuperviser) removeState() error {

--- a/superviser/nodeos/superviser.go
+++ b/superviser/nodeos/superviser.go
@@ -16,6 +16,7 @@ package nodeos
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -157,9 +158,16 @@ func (s *NodeosSuperviser) HasData() bool {
 }
 
 func (s *NodeosSuperviser) removeState() error {
-	err := os.RemoveAll(path.Join(path.Join(s.options.DataDir, "state")))
+	stateDir := path.Join(s.options.DataDir, "state")
+	dir, err := ioutil.ReadDir(stateDir)
 	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("cannot delete state directory: %w", err)
+		return fmt.Errorf("cannot read state directory: %w", err)
+	}
+	for _, file := range dir {
+		err = os.RemoveAll(path.Join(stateDir, file.Name()))
+		if err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("cannot delete state: %w", err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
It's common to have state and block folder mounted (for example when using ZFS). Using RemoveAll on the state folder will fail in that case as mounted ZFS filesystems cannot be deleted. This change removes the content of the state dir instead of the folder itself. 