### PR TITLE
auto toggle one-block-files vs merged, restore partial merged on start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+* New Feature: `auto-merge` the mindreader will switch between producing merged-blocks and one-block files depending on the existence of merged files in destination store and on the age of the blocks. It will also never overwrite destination files (unless BatchMode is set)
+* New Feature: when producing merged files, a partial file will be produced on shutdown. If the next block to appear on next startup is the expected one, it will load the partial file to continue producing a merged-blocks file.
+* New option 'BatchMode' forces the mindreader to produce merged-blocks all the time (without checking block age or existence of merged files in block store) and to overwrite any existing merged-blocks files.
+* New option MergeThresholdBlockAge: defines the age at which a block is considered old enough to be included in a merged-block-file directly (without any risk of forking).
+
+### Removed
+* `discardAfterStopBlock`: this option did not give any value, especially now that the mindreader can switch between producing merged blocks and one-block files
+* `merge_upload_directly`: that feature is now automatically enabled (see new `auto-merge` feature), the `BatchMode` option can force that behavior now.
+
+
 ## [v0.0.1] - 2020-06-22
 
 ### Fixed:

--- a/app/node_mindreader_stdin/app.go
+++ b/app/node_mindreader_stdin/app.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/dfuse-io/bstream"
 	"github.com/dfuse-io/bstream/blockstream"
 	"github.com/dfuse-io/dgrpc"
 	nodeManager "github.com/dfuse-io/node-manager"
@@ -47,6 +48,7 @@ type Modules struct {
 	ConsoleReaderFactory       mindreader.ConsolerReaderFactory
 	ConsoleReaderTransformer   mindreader.ConsoleReaderBlockTransformer
 	MetricsAndReadinessManager *nodeManager.MetricsAndReadinessManager
+	Tracker                    *bstream.Tracker
 }
 
 type App struct {
@@ -82,9 +84,9 @@ func (a *App) Run() error {
 		a.Config.WorkingDir,
 		a.modules.ConsoleReaderFactory,
 		a.modules.ConsoleReaderTransformer,
+		a.modules.Tracker,
 		a.Config.StartBlockNum,
 		a.Config.StopBlockNum,
-		a.Config.DiscardAfterStopBlock,
 		a.Config.MindReadBlocksChanCapacity,
 		a.modules.MetricsAndReadinessManager.UpdateHeadBlock,
 		func() {},

--- a/app/node_mindreader_stdin/app.go
+++ b/app/node_mindreader_stdin/app.go
@@ -32,7 +32,8 @@ type Config struct {
 	GRPCAddr                     string
 	ArchiveStoreURL              string
 	MergeArchiveStoreURL         string
-	MergeUploadDirectly          bool
+	BatchMode                    bool
+	MergeThresholdBlockAge       time.Duration
 	MindReadBlocksChanCapacity   int
 	FailOnNonContinuousBlocks    bool
 	StartBlockNum                uint64
@@ -76,7 +77,8 @@ func (a *App) Run() error {
 	mindreaderLogPlugin, err := mindreader.NewMindReaderPlugin(
 		a.Config.ArchiveStoreURL,
 		a.Config.MergeArchiveStoreURL,
-		a.Config.MergeUploadDirectly,
+		a.Config.BatchMode,
+		a.Config.MergeThresholdBlockAge,
 		a.Config.WorkingDir,
 		a.modules.ConsoleReaderFactory,
 		a.modules.ConsoleReaderTransformer,

--- a/mindreader/archiver_selector.go
+++ b/mindreader/archiver_selector.go
@@ -1,0 +1,239 @@
+// Copyright 2019 dfuse Platform Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mindreader
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/dfuse-io/bstream"
+	"go.uber.org/atomic"
+	"go.uber.org/zap"
+)
+
+type ArchiverSelector struct {
+	oneblockArchiver Archiver
+	mergeArchiver    Archiver
+
+	blockReaderFactory bstream.BlockReaderFactory
+
+	firstBlockPassed    bool
+	firstBoundaryPassed bool
+	currentlyMerging    bool
+
+	batchMode              bool // forces merging blocks without tracker or LIB checking
+	tracker                *bstream.Tracker
+	mergeThresholdBlockAge time.Duration
+	lastSeenLIB            *atomic.Uint64
+
+	workDir string
+	logger  *zap.Logger
+}
+
+func NewArchiverSelector(
+	oneblockArchiver Archiver,
+	mergeArchiver Archiver,
+	blockReaderFactory bstream.BlockReaderFactory,
+	batchMode bool,
+	tracker *bstream.Tracker,
+	mergeThresholdBlockAge time.Duration,
+	workDir string,
+	logger *zap.Logger,
+) *ArchiverSelector {
+	s := &ArchiverSelector{
+		oneblockArchiver:       oneblockArchiver,
+		mergeArchiver:          mergeArchiver,
+		blockReaderFactory:     blockReaderFactory,
+		batchMode:              batchMode,
+		tracker:                tracker,
+		mergeThresholdBlockAge: mergeThresholdBlockAge,
+		lastSeenLIB:            atomic.NewUint64(0),
+		workDir:                workDir,
+		logger:                 logger,
+	}
+	s.updateLastSeenLIB()
+	return s
+}
+
+func (s *ArchiverSelector) updateLastSeenLIB() {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	ref, err := s.tracker.Get(ctx, bstream.NetworkLIBTarget)
+	if err != nil {
+		s.logger.Warn("cannot get lib from tracker", zap.Error(err))
+		return
+	}
+	s.lastSeenLIB.Store(ref.Num())
+}
+
+// shouldMerge completely manages 'currentlyMerging', 'firstBoundaryPassed' and 'firstBlockPassed'
+func (s *ArchiverSelector) shouldMerge(block *bstream.Block) (should bool, writeToBoth bool, previousBlocks []*bstream.Block) {
+	if s.firstBoundaryPassed && !s.currentlyMerging {
+		return false, false, nil // never go back to merging after passing a boundary
+	}
+
+	blockNum := block.Num()
+	isBoundaryBlock := (blockNum%100 == 0 || blockNum == bstream.GetProtocolFirstStreamableBlock)
+	if !isBoundaryBlock {
+		if s.firstBlockPassed {
+			return s.currentlyMerging, false, nil //only change merging state on boundaries or initial block
+		}
+		s.firstBlockPassed = true
+
+		previousBlocks = s.loadLastPartial(blockNum)
+		if previousBlocks == nil {
+			return false, false, nil // never suggest 'merging' when we are not on a boundary and have no partial blocks
+		}
+	} else {
+		s.firstBoundaryPassed = true
+	}
+	s.firstBlockPassed = true
+
+	lastSeenLIB := s.lastSeenLIB.Load()
+	if blockNum+10000 >= lastSeenLIB { // optimization: skip doing this every time if blockNum is "not even close"
+		go s.updateLastSeenLIB() // for next time
+	}
+
+	blockAge := time.Since(block.Time())
+	if blockAge > s.mergeThresholdBlockAge {
+		s.logger.Info("merging next blocks directly because they are older than threshold", zap.Uint64("block_num", blockNum), zap.Duration("block_age", blockAge))
+		writeToBoth = s.currentlyMerging == false
+		s.currentlyMerging = true
+		return true, writeToBoth, previousBlocks
+	}
+
+	if blockNum+100 <= lastSeenLIB {
+		s.logger.Info("merging next blocks directly because they are older than LIB", zap.Uint64("block_num", blockNum), zap.Uint64("lib", lastSeenLIB))
+		writeToBoth = s.currentlyMerging == false
+		s.currentlyMerging = true
+		return true, writeToBoth, previousBlocks
+	}
+
+	s.logger.Info("producing one-block files...", zap.Uint64("block_num", blockNum))
+	s.currentlyMerging = false
+	return false, false, previousBlocks
+}
+
+func (s *ArchiverSelector) loadLastPartial(next uint64) []*bstream.Block {
+	matches, err := filepath.Glob(filepath.Join(s.workDir, "archiver_*.partial"))
+	if err != nil {
+		s.logger.Warn("trying to find glob for partial archive", zap.Error(err))
+		return nil
+	}
+	for _, match := range matches {
+		saved := filepath.Base(match)
+		if len(saved) != 27 {
+			s.logger.Error("trying to restore partial archive but got invalid filename", zap.String("saved", saved), zap.Int("length", len(saved)))
+			continue
+		}
+		savedNum, err := strconv.ParseUint(saved[9:19], 10, 64)
+		if err != nil {
+			s.logger.Error("trying to restore partial archive but got invalid number from filename", zap.String("saved", saved[9:19]), zap.Error(err))
+			continue
+		}
+		if savedNum != next {
+			s.logger.Info("last partial block file does not match saved, deleting file", zap.Uint64("next", next), zap.Uint64("saved_partial", savedNum))
+			os.Remove(match)
+			continue
+		}
+
+		f, err := os.Open(match)
+		if err != nil {
+			s.logger.Error("trying to restore partial archive but got cannot open file. deleting it", zap.String("filename", match), zap.Error(err))
+			os.Remove(match)
+			continue
+		}
+
+		blockReader, err := s.blockReaderFactory.New(f)
+		if err != nil {
+			s.logger.Error("trying to generate blockreader with file on restore", zap.Error(err))
+			f.Close()
+			return nil
+		}
+
+		var blocks []*bstream.Block
+		for {
+			blk, err := blockReader.Read()
+			if blk != nil {
+				blocks = append(blocks, blk)
+			}
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				s.logger.Error("trying to read block on partial archive restore caused an error. deleting file", zap.Error(err))
+				os.Remove(match)
+				f.Close()
+				return nil
+			}
+		}
+		f.Close()
+		os.Remove(match)
+		return blocks
+	}
+
+	return nil
+}
+
+func (s *ArchiverSelector) StoreBlock(block *bstream.Block) error {
+
+	shouldMerge, writeToBoth, previousBlocks := s.shouldMerge(block)
+
+	arch := s.oneblockArchiver
+	if shouldMerge {
+		arch = s.mergeArchiver
+	}
+
+	for _, blk := range previousBlocks {
+		if err := arch.StoreBlock(blk); err != nil {
+			return err
+		}
+	}
+	if writeToBoth {
+		if err := s.oneblockArchiver.StoreBlock(block); err != nil {
+			return err
+		}
+	}
+	return arch.StoreBlock(block)
+}
+
+func (s *ArchiverSelector) Start() {
+	s.logger.Info("Starting OneBlock uploads")
+	go s.oneblockArchiver.Start()
+	s.logger.Info("Starting MergedBlocks uploads")
+	go s.mergeArchiver.Start()
+}
+
+// Terminate assumes that no more 'StoreBlock' command is coming
+func (s *ArchiverSelector) Terminate() <-chan interface{} {
+	ch := make(chan interface{})
+	go func() {
+		<-s.mergeArchiver.Terminate()
+		<-s.oneblockArchiver.Terminate()
+		close(ch)
+	}()
+	return ch
+}
+
+func (s *ArchiverSelector) Init() error {
+	if err := s.oneblockArchiver.Init(); err != nil {
+		return err
+	}
+	return s.mergeArchiver.Init()
+}

--- a/mindreader/archiver_selector_test.go
+++ b/mindreader/archiver_selector_test.go
@@ -1,0 +1,122 @@
+// Copyright 2019 dfuse Platform Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mindreader
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/dfuse-io/bstream"
+	"github.com/dfuse-io/dstore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+var now = time.Now()
+
+func testNewMergeArchiver(path string, store dstore.Store) *MergeArchiver {
+	return NewMergeArchiver(store, testBlockWriteFactory, path, testLogger)
+}
+
+func genBlocks(nums ...uint64) (out []*bstream.Block) {
+	for _, num := range nums {
+		out = append(out, &bstream.Block{Number: num, PayloadBuffer: []byte{0x01}, Timestamp: now.Add(-time.Hour).Add(time.Second * time.Duration(num))})
+	}
+	return
+}
+
+func TestArchiverSelector(t *testing.T) {
+
+	tests := []struct {
+		name               string
+		input              []*bstream.Block
+		mergeTimeThreshold time.Duration
+		expectMergedBlocks []*bstream.Block
+		expectOneBlocks    []*bstream.Block
+	}{
+		{
+			name:               "one block",
+			input:              genBlocks(99),
+			mergeTimeThreshold: 999 * time.Hour,
+			expectMergedBlocks: nil,
+			expectOneBlocks:    genBlocks(99),
+		},
+		{
+			name:               "one old block",
+			input:              genBlocks(99),
+			mergeTimeThreshold: time.Minute,
+			expectMergedBlocks: nil,
+			expectOneBlocks:    genBlocks(99),
+		},
+		{
+			name:               "one boundary old block",
+			input:              genBlocks(100),
+			mergeTimeThreshold: time.Minute,
+			expectMergedBlocks: genBlocks(100),
+			expectOneBlocks:    nil,
+		},
+		{
+			name:               "multiple old blocks starting on boundary",
+			input:              genBlocks(100, 101, 102, 103),
+			mergeTimeThreshold: time.Minute,
+			expectMergedBlocks: genBlocks(100, 101, 102, 103),
+			expectOneBlocks:    nil,
+		},
+		{
+			name:               "multiple old blocks traverse boundary",
+			input:              genBlocks(98, 99, 100, 101, 102),
+			mergeTimeThreshold: time.Minute,
+			expectMergedBlocks: genBlocks(100, 101, 102),
+			expectOneBlocks:    genBlocks(98, 99, 100),
+		},
+		{
+			name:               "multiple young blocks traverse boundary",
+			input:              genBlocks(98, 99, 100, 101, 102),
+			mergeTimeThreshold: 999 * time.Hour,
+			expectMergedBlocks: nil,
+			expectOneBlocks:    genBlocks(98, 99, 100, 101, 102),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir, err := ioutil.TempDir("/tmp", "test-mindreader-archiver-selector")
+			if err != nil {
+				log.Fatal(err)
+			}
+			defer os.RemoveAll(dir)
+
+			ma := &testArchiver{}
+			oa := &testArchiver{}
+
+			tracker := bstream.NewTracker(0)
+
+			s := NewArchiverSelector(oa, ma, bstream.GetBlockReaderFactory, false, tracker, test.mergeTimeThreshold, dir, zap.NewNop())
+
+			s.Init()
+
+			for _, blk := range test.input {
+				require.NoError(t, s.StoreBlock(blk))
+			}
+
+			assert.Equal(t, test.expectOneBlocks, oa.blocks)
+			assert.Equal(t, test.expectMergedBlocks, ma.blocks)
+		})
+	}
+}

--- a/mindreader/archiver_test.go
+++ b/mindreader/archiver_test.go
@@ -122,9 +122,8 @@ func TestMindReaderPlugin_StopAtBlockNumReached(t *testing.T) {
 
 func TestNewLocalStore(t *testing.T) {
 	localArchiveStore, err := dstore.NewDBinStore("/tmp/mr_dest")
-	localArchiveMergedStore, err := dstore.NewDBinStore("/tmp/mr_dest_merged")
 	require.NoError(t, err)
-	archiver := testNewArchiver("/tmp/mr_test", localArchiveStore, localArchiveMergedStore)
+	archiver := testNewArchiver("/tmp/mr_test", localArchiveStore)
 	err = archiver.Init()
 	require.NoError(t, err)
 
@@ -155,12 +154,10 @@ func TestNewGSStore(t *testing.T) {
 	t.Skip()
 
 	path := "gs://example/dev"
-	mergedPath := fmt.Sprintf("%s-merged", path)
 	//path := "gs://charlestest1/dev"
 
 	archiveStore, err := dstore.NewDBinStore(path)
-	archiveMergedStore, err := dstore.NewDBinStore(mergedPath)
-	archiver := testNewArchiver("/tmp/mr_test/", archiveStore, archiveMergedStore)
+	archiver := testNewArchiver("/tmp/mr_test/", archiveStore)
 	err = archiver.Init()
 	require.NoError(t, err)
 
@@ -181,8 +178,8 @@ func TestNewGSStore(t *testing.T) {
 	require.True(t, exists)
 }
 
-func testNewArchiver(path string, store dstore.Store, mergedStore dstore.Store) *HybridArchiver {
-	return NewHybridArchiver(store, mergedStore, testBlockWriteFactory, nil, bstream.NewTracker(200), time.Hour*99999, path, testLogger)
+func testNewArchiver(path string, store dstore.Store) *OneBlockArchiver {
+	return NewOneBlockArchiver(store, testBlockWriteFactory, path, testLogger)
 }
 
 func testNewMindReaderPlugin(archiver Archiver, startBlock, stopBlock uint64) (*MindReaderPlugin, error) {

--- a/mindreader/archiver_test.go
+++ b/mindreader/archiver_test.go
@@ -277,3 +277,24 @@ func testConsoleReaderBlockTransformer(obj interface{}) (*bstream.Block, error) 
 		Number: uint64(eos.BlockNum(data.ID)),
 	}, nil
 }
+
+type testArchiver struct {
+	blocks []*bstream.Block
+}
+
+func (_ *testArchiver) Init() error {
+	return nil
+}
+func (_ *testArchiver) Terminate() <-chan interface{} {
+	out := make(chan interface{})
+	close(out)
+	return out
+}
+
+func (_ *testArchiver) Start() {
+}
+
+func (a *testArchiver) StoreBlock(block *bstream.Block) error {
+	a.blocks = append(a.blocks, block)
+	return nil
+}

--- a/mindreader/archiver_test.go
+++ b/mindreader/archiver_test.go
@@ -182,7 +182,7 @@ func TestNewGSStore(t *testing.T) {
 }
 
 func testNewArchiver(path string, store dstore.Store, mergedStore dstore.Store) *HybridArchiver {
-	return NewHybridArchiver(store, mergedStore, testBlockWriteFactory, nil, time.Hour*99999, path, testLogger)
+	return NewHybridArchiver(store, mergedStore, testBlockWriteFactory, nil, bstream.NewTracker(200), time.Hour*99999, path, testLogger)
 }
 
 func testNewMindReaderPlugin(archiver Archiver, startBlock, stopBlock uint64) (*MindReaderPlugin, error) {

--- a/mindreader/init_test.go
+++ b/mindreader/init_test.go
@@ -47,7 +47,7 @@ func (s *TestStore) Init() error {
 	return nil
 }
 
-func (s *TestStore) WaitForAllFilesToUpload() <-chan interface{} {
+func (s *TestStore) Terminate() <-chan interface{} {
 	ch := make(chan interface{})
 	close(ch)
 	return ch
@@ -72,6 +72,5 @@ func (s *TestStore) consumeBlockFromChannel(t *testing.T, timeout time.Duration)
 	return nil
 }
 
-func (s *TestStore) uploadFiles() error {
-	return nil
+func (s *TestStore) Start() {
 }

--- a/mindreader/init_test.go
+++ b/mindreader/init_test.go
@@ -53,7 +53,7 @@ func (s *TestStore) WaitForAllFilesToUpload() <-chan interface{} {
 	return ch
 }
 
-func (s *TestStore) storeBlock(block *bstream.Block) error {
+func (s *TestStore) StoreBlock(block *bstream.Block) error {
 	s.blocks = append(s.blocks, block)
 	s.receivedBlock <- block
 	return nil

--- a/mindreader/merge_archiver_test.go
+++ b/mindreader/merge_archiver_test.go
@@ -42,27 +42,27 @@ func TestMergeArchiver(t *testing.T) {
 		eg:                 llerrgroup.New(2),
 	}
 
-	assert.NoError(t, a.storeBlock(&bstream.Block{Number: 99, PayloadBuffer: []byte{0x01}}))
+	assert.NoError(t, a.StoreBlock(&bstream.Block{Number: 99, PayloadBuffer: []byte{0x01}}))
 	assert.Nil(t, a.buffer)
 
-	assert.NoError(t, a.storeBlock(&bstream.Block{Number: 100, PayloadBuffer: []byte{0x01}}))
+	assert.NoError(t, a.StoreBlock(&bstream.Block{Number: 100, PayloadBuffer: []byte{0x01}}))
 	assert.NotNil(t, a.buffer)
 	assert.Equal(t, uint64(101), a.expectBlock)
 	prevSize := a.buffer.Len()
 
-	assert.Error(t, a.storeBlock(&bstream.Block{Number: 99, PayloadBuffer: []byte{0x01}}))
+	assert.Error(t, a.StoreBlock(&bstream.Block{Number: 99, PayloadBuffer: []byte{0x01}}))
 
 	for i := 101; i < 199; i++ {
-		assert.NoError(t, a.storeBlock(&bstream.Block{Number: uint64(i), PayloadBuffer: []byte{0x01}}))
+		assert.NoError(t, a.StoreBlock(&bstream.Block{Number: uint64(i), PayloadBuffer: []byte{0x01}}))
 		assert.True(t, a.buffer.Len() > prevSize)
 		assert.Equal(t, uint64(i+1), a.expectBlock)
 		prevSize = a.buffer.Len()
 	}
 
-	assert.NoError(t, a.storeBlock(&bstream.Block{Number: 199, PayloadBuffer: []byte{0x01}}))
+	assert.NoError(t, a.StoreBlock(&bstream.Block{Number: 199, PayloadBuffer: []byte{0x01}}))
 	assert.True(t, a.buffer.Len() > prevSize)
 
-	assert.NoError(t, a.storeBlock(&bstream.Block{Number: 300, PayloadBuffer: []byte{0x01}}), "should accept any block ...00 after block ...99")
+	assert.NoError(t, a.StoreBlock(&bstream.Block{Number: 300, PayloadBuffer: []byte{0x01}}), "should accept any block ...00 after block ...99")
 	assert.True(t, a.buffer.Len() < prevSize)
 	assert.True(t, a.buffer.Len() > 0)
 	assert.Equal(t, uint64(301), a.expectBlock)
@@ -76,13 +76,13 @@ func TestMergeArchiverSpecialCase(t *testing.T) {
 		blockWriterFactory: bstream.GetBlockWriterFactory,
 	}
 
-	assert.NoError(t, a.storeBlock(&bstream.Block{Number: 1, PayloadBuffer: []byte{0x01}}))
+	assert.NoError(t, a.StoreBlock(&bstream.Block{Number: 1, PayloadBuffer: []byte{0x01}}))
 	assert.NotNil(t, a.buffer)
 	assert.Equal(t, uint64(2), a.expectBlock)
 	prevSize := a.buffer.Len()
 
 	for i := 2; i < 99; i++ {
-		assert.NoError(t, a.storeBlock(&bstream.Block{Number: uint64(i), PayloadBuffer: []byte{0x01}}))
+		assert.NoError(t, a.StoreBlock(&bstream.Block{Number: uint64(i), PayloadBuffer: []byte{0x01}}))
 		assert.True(t, a.buffer.Len() > prevSize)
 		assert.Equal(t, uint64(i+1), a.expectBlock)
 		prevSize = a.buffer.Len()

--- a/mindreader/merge_archiver_test.go
+++ b/mindreader/merge_archiver_test.go
@@ -32,6 +32,11 @@ func init() {
 			DBinWriter: dbin.NewWriter(writer),
 		}, nil
 	})
+	bstream.GetBlockReaderFactory = bstream.BlockReaderFactoryFunc(func(reader io.Reader) (bstream.BlockReader, error) {
+		return &bstream.TestBlockReaderBin{
+			DBinReader: dbin.NewReader(reader),
+		}, nil
+	})
 }
 func TestMergeArchiver(t *testing.T) {
 	mStore := dstore.NewMockStore(nil)

--- a/mindreader/merge_archiver_test.go
+++ b/mindreader/merge_archiver_test.go
@@ -48,20 +48,25 @@ func TestMergeArchiver(t *testing.T) {
 	assert.NoError(t, a.storeBlock(&bstream.Block{Number: 100, PayloadBuffer: []byte{0x01}}))
 	assert.NotNil(t, a.buffer)
 	assert.Equal(t, uint64(101), a.expectBlock)
-	size := a.buffer.Len()
+	prevSize := a.buffer.Len()
 
 	assert.Error(t, a.storeBlock(&bstream.Block{Number: 99, PayloadBuffer: []byte{0x01}}))
 
 	for i := 101; i < 199; i++ {
 		assert.NoError(t, a.storeBlock(&bstream.Block{Number: uint64(i), PayloadBuffer: []byte{0x01}}))
-		assert.True(t, a.buffer.Len() > size)
+		assert.True(t, a.buffer.Len() > prevSize)
 		assert.Equal(t, uint64(i+1), a.expectBlock)
-		size = a.buffer.Len()
+		prevSize = a.buffer.Len()
 	}
 
 	assert.NoError(t, a.storeBlock(&bstream.Block{Number: 199, PayloadBuffer: []byte{0x01}}))
-	assert.True(t, a.buffer.Len() > size)
-	assert.Equal(t, uint64(200), a.expectBlock)
+	assert.True(t, a.buffer.Len() > prevSize)
+
+	assert.NoError(t, a.storeBlock(&bstream.Block{Number: 300, PayloadBuffer: []byte{0x01}}), "should accept any block ...00 after block ...99")
+	assert.True(t, a.buffer.Len() < prevSize)
+	assert.True(t, a.buffer.Len() > 0)
+	assert.Equal(t, uint64(301), a.expectBlock)
+
 }
 
 func TestMergeArchiverSpecialCase(t *testing.T) {
@@ -74,12 +79,12 @@ func TestMergeArchiverSpecialCase(t *testing.T) {
 	assert.NoError(t, a.storeBlock(&bstream.Block{Number: 1, PayloadBuffer: []byte{0x01}}))
 	assert.NotNil(t, a.buffer)
 	assert.Equal(t, uint64(2), a.expectBlock)
-	size := a.buffer.Len()
+	prevSize := a.buffer.Len()
 
 	for i := 2; i < 99; i++ {
 		assert.NoError(t, a.storeBlock(&bstream.Block{Number: uint64(i), PayloadBuffer: []byte{0x01}}))
-		assert.True(t, a.buffer.Len() > size)
+		assert.True(t, a.buffer.Len() > prevSize)
 		assert.Equal(t, uint64(i+1), a.expectBlock)
-		size = a.buffer.Len()
+		prevSize = a.buffer.Len()
 	}
 }


### PR DESCRIPTION
* addresses https://github.com/dfuse-io/dfuse-eosio/issues/99
* addresses https://github.com/dfuse-io/dfuse-eosio/issues/81

### Added
* New Feature: `auto-merge` the mindreader will switch between producing merged-blocks and one-block files depending on the existence of merged files in destination store and on the age of the blocks. It will also never overwrite destination files (unless BatchMode is set)
* New Feature: when producing merged files, a partial file will be produced on shutdown. If the next block to appear on next startup is the expected one, it will load the partial file to continue producing a merged-blocks file.
* New option 'BatchMode' forces the mindreader to produce merged-blocks all the time (without checking block age or existence of merged files in block store) and to overwrite any existing merged-blocks files.
* New option MergeThresholdBlockAge: defines the age at which a block is considered old enough to be included in a merged-block-file directly (without any risk of forking).

### Removed
* `discardAfterStopBlock`: this option did not give any value, especially now that the mindreader can switch between producing merged blocks and one-block files
* `merge_upload_directly`: that feature is now automatically enabled (see new `auto-merge` feature), the `BatchMode` option can force that behavior now.